### PR TITLE
Generalization of installation scripts

### DIFF
--- a/installer/install_project.sh
+++ b/installer/install_project.sh
@@ -83,7 +83,7 @@ else
 fi
 
 # Restart Apache service
-systemctl restart $APACHE_SERVICE
+service $APACHE_SERVICE restart
 
 #############################
 # Install Fitcrack database #

--- a/installer/set_vars.sh
+++ b/installer/set_vars.sh
@@ -118,7 +118,7 @@ fi
 read -e -p "Enter the name of Apache service (default: $DEFAULT_APACHE_SERVICE): " APACHE_SERVICE
 APACHE_SERVICE=${APACHE_SERVICE:-$DEFAULT_APACHE_SERVICE}
 
-systemctl | grep $APACHE_SERVICE >/dev/null 2>/dev/null
+service --status-all 2>&1 | grep $APACHE_SERVICE >/dev/null 2>/dev/null
 
 if [[ $? != 0 ]]; then
   echo "Error: $APACHE_SERVICE not found via systemctl."

--- a/server/sql/10_create_tables.sql
+++ b/server/sql/10_create_tables.sql
@@ -289,7 +289,7 @@ CREATE TABLE IF NOT EXISTS `fc_job` (
 -- Štruktúra tabuľky pre tabuľku `fc_job_dictionary`
 --
 
-CREATE TABLE `fc_job_dictionary` (
+CREATE TABLE IF NOT EXISTS `fc_job_dictionary` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `job_id` bigint(20) unsigned NOT NULL,
   `dictionary_id` bigint(20) unsigned NOT NULL,


### PR DESCRIPTION
Fix SQL script and exchange `systemctl` (limited to `systemd`) for `service` (more general according to [Serverfault StackExchange](https://serverfault.com/questions/867322/what-is-the-difference-between-service-and-systemctl)