### PR TITLE
Add support for Rocky Linux

### DIFF
--- a/installer/detect_distro.sh
+++ b/installer/detect_distro.sh
@@ -43,7 +43,7 @@ case $ID in
         DEFAULT_APACHE_DOCUMENT_ROOT="/var/www/html"
         DEFAULT_APACHE_SERVICE="apache2"
         ;;
-    centos|redhat)
+    centos|redhat|rocky)
         DEFAULT_APACHE_USER="apache"
         DEFAULT_APACHE_CONFIG_DIR="/etc/httpd"
         DEFAULT_APACHE_CONFIG_FILE="/etc/httpd/conf/httpd.conf"

--- a/installer/install_project.sh
+++ b/installer/install_project.sh
@@ -135,7 +135,7 @@ if [ $SERVICE_INSTALL = "y" ]; then
     debian|ubuntu)
       update-rc.d fitcrack defaults
     ;;
-    centos|redhat)
+    centos|redhat|rocky)
       chkconfig --add fitcrack
       chkconfig --level 2345 fitcrack on
     ;;

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -48,7 +48,7 @@ if [ -d "$BOINC_PROJECT_DIR" ]; then
       debian|ubuntu)
         update-rc.d fitcrack remove
       ;;
-      centos|redhat)
+      centos|redhat|rocky)
         chkconfig --level 2345 fitcrack off
         chkconfig --del fitcrack
       ;;


### PR DESCRIPTION
This PR adds support for Rocky Linux. For context, Rocky Linux is a bug-for-bug RHEL-compatible distro, and is one of the popular distros seeking to fill the gap CentOS has left.

As it's RHEL-compatible, all that is required is to add it to the existing cases in the installer scripts.

I've tested this out and it all works fine 👍.