### PR TITLE
Use Random Token for Flask Secret

### DIFF
--- a/webadmin/fitcrackAPI/src/app.py
+++ b/webadmin/fitcrackAPI/src/app.py
@@ -4,6 +4,7 @@
 '''
 
 import logging.config
+import secrets
 
 from flask import Flask, Blueprint, request, url_for
 from flask_cors import CORS
@@ -43,7 +44,7 @@ app = Flask(__name__)
 
 
 def configure_app(flask_app):
-    flask_app.config['SECRET_KEY'] = 'fitcrack456152'
+    flask_app.config['SECRET_KEY'] = secrets.token_hex(16)
     # flask_app.config['SERVER_NAME'] = settings.FLASK_SERVER_NAME
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
     flask_app.config['SQLALCHEMY_DATABASE_URI'] = settings.SQLALCHEMY_DATABASE_URI


### PR DESCRIPTION
Addresses https://github.com/nesfit/fitcrack/issues/41

`secrets.token_hex(16)` will create a secure, 16-byte random key for Flask, used to sign cookies and JWTs.
All tested working.