### PR TITLE
Set HTML title to Fitcrack

### DIFF
--- a/webadmin/fitcrackFE/index.html
+++ b/webadmin/fitcrackFE/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="shortcut icon" type="image/png" href="/static/favicon.png"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>Fitcrack</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
When the frontend first loads, the HTML title briefly shows "Vite App" before the javascript bundle has a chance to load. This just patches that up so it shows "Fitcrack" as it first loads.