### PR TITLE
Fix certain library files being only half-deleted

### DIFF
--- a/webadmin/fitcrackAPI/src/src/api/fitcrack/endpoints/markov/markov.py
+++ b/webadmin/fitcrackAPI/src/src/api/fitcrack/endpoints/markov/markov.py
@@ -94,6 +94,9 @@ class markov(Resource):
         markov = FcHcstat.query.filter(FcHcstat.id == id).one()
         markov.deleted = True
         db.session.commit()
+        path = os.path.join(HCSTATS_DIR, markov.path)
+        if os.path.exists(path):
+            os.remove(path)
         return {
             'status': True,
             'message': 'Markov files successfully deleted.'

--- a/webadmin/fitcrackAPI/src/src/api/fitcrack/endpoints/masks/masks.py
+++ b/webadmin/fitcrackAPI/src/src/api/fitcrack/endpoints/masks/masks.py
@@ -110,6 +110,9 @@ class mask(Resource):
         mask = FcMasksSet.query.filter(FcMasksSet.id == id).one()
         mask.deleted = True
         db.session.commit()
+        path = os.path.join(MASKS_DIR, mask.path)
+        if os.path.exists(path):
+            os.remove(path)
         return {
             'status': True,
             'message': 'Mask file sucesfully deleted.'


### PR DESCRIPTION
This PR fixes (or tries to fix) issue nesfit/fitcrack#68, which I raised.

What I did is I took the file-deletion code from an endpoint that didn't have any problems, like charset,

https://github.com/nesfit/fitcrack/blob/f2a0232dd77ef7b4a0ff1fceb736b3d8f169a057/webadmin/fitcrackAPI/src/src/api/fitcrack/endpoints/charset/charset.py#L99-L113

and copied it to the two endpoints that do have the issue (Markov files and mask sets). The same or similar file-deletion code is present also in other library endpoints, so I think the issue is just that the file-deletion code was forgotten to be pasted in.

I tested the fix and it seems to have resolved the issue, at least to my knowledge.