### PR TITLE
Improve mask-file validation

### DIFF
--- a/webadmin/fitcrackAPI/src/src/api/fitcrack/attacks/functions.py
+++ b/webadmin/fitcrackAPI/src/src/api/fitcrack/attacks/functions.py
@@ -17,7 +17,10 @@ from src.database import db
 from src.database.models import FcDictionary
 
 def check_mask_syntax(mask):
-    if not re.fullmatch("^(\?[ludhHsab]|[ -~])+$", mask):
+    #Allowed are either variables (? followed by an allowed character)
+    #or static letters (any printable ASCII character or space except ?).
+    #https://hashcat.net/wiki/doku.php?id=mask_attack for complete reference.
+    if not re.fullmatch("^(\?[ludhHsab?1234]|[ ->@-~])+$", mask):
         abort(400, 'Wrong mask ' + mask)
 
 


### PR DESCRIPTION
Hi,

This PR should fix issue #74. I changed the regex that performs mask validation.

I changed the first section to `?[ludhHsab?1234]`. Previously, this part would reject `?1`, `?2`, `?3`, and `?4`, which are valid variables, and it would reject `??`, the escape sequence for the `?` character.

I changed the second section to `[ ->@-~]` (any printable ASCII character and space with the exception of `?`). Previously, this section would make the first section useless—`?:`, an invalid variable, would be incorrectly recognised as two static letters.

I tested the changes, and Webadmin now rejects the invalid mask file from issue #74.
