### PR TITLE
Install WebAdmin dependencies in a dedicated venv

### DIFF
--- a/INSTALL-Installer.md
+++ b/INSTALL-Installer.md
@@ -108,7 +108,9 @@ npm -v
 
 ### Install Python packages
 ```bash
-python3 -m pip install --break-system-packages --ignore-installed urllib3==1.26.15 mysqlclient
+python3 -m venv /opt/fitcrack-webadmin-venv
+/opt/fitcrack-webadmin-venv/bin/python3 -m pip install --upgrade pip
+/opt/fitcrack-webadmin-venv/bin/python3 -m pip install --ignore-installed urllib3==1.26.15 mysqlclient
 ```
 
 ### Setup the MariaDB server
@@ -190,7 +192,9 @@ dnf install -y \
 
 ### Install Python packages for Fitcrack
 ```bash
-python3 -m pip install --ignore-installed mysqlclient urllib3==1.26.15
+python3 -m venv /opt/fitcrack-webadmin-venv
+/opt/fitcrack-webadmin-venv/bin/python3 -m pip install --upgrade pip
+/opt/fitcrack-webadmin-venv/bin/python3 -m pip install --ignore-installed mysqlclient urllib3==1.26.15
 ```
 
 ### Install Node 16.15

--- a/installer/install_webadmin.sh
+++ b/installer/install_webadmin.sh
@@ -9,7 +9,8 @@
 ##################################
 
 echo "Installing back-end requirements..."
-python3 -m pip install --break-system-packages --ignore-installed -r webadmin/fitcrackAPI/src/requirements.txt
+WEBADMIN_VENV_PATH="$APACHE_DOCUMENT_ROOT/fitcrackAPI/.venv"
+echo "Back-end dependencies will be installed into a dedicated virtualenv: $WEBADMIN_VENV_PATH"
 echo "Done."
 
 ####################################
@@ -191,7 +192,7 @@ else
   fi
 
   echo "<VirtualHost *:$BACKEND_PORT>" >> $BE_CONFIG_FILE
-  echo "  WSGIDaemonProcess fitcrack user=$APACHE_USER group=$APACHE_USER threads=5" >> $BE_CONFIG_FILE
+  echo "  WSGIDaemonProcess fitcrack user=$APACHE_USER group=$APACHE_USER threads=5 python-home=$WEBADMIN_VENV_PATH" >> $BE_CONFIG_FILE
   echo "  WSGIScriptAlias / $APACHE_DOCUMENT_ROOT/fitcrackAPI/src/wsgi.py" >> $BE_CONFIG_FILE
   echo "  WSGIPassAuthorization On" >> $BE_CONFIG_FILE
   echo "  <Directory $APACHE_DOCUMENT_ROOT/fitcrackAPI/src/>" >> $BE_CONFIG_FILE
@@ -293,6 +294,29 @@ if [ $INSTALL_BACKEND = "y" ]; then
   chown -R $APACHE_USER:$APACHE_GROUP $APACHE_DOCUMENT_ROOT/fitcrackAPI
 
   echo "Installed to $APACHE_DOCUMENT_ROOT/fitcrackAPI."
+fi
+
+if [ -d "$APACHE_DOCUMENT_ROOT/fitcrackAPI/src" ]; then
+  echo "Installing Python dependencies into WebAdmin virtualenv..."
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python3 is not available. Install python3 and python3-venv first."
+    exit 1
+  fi
+
+  python3 -m venv "$WEBADMIN_VENV_PATH"
+  if [ $? -ne 0 ]; then
+    echo "Failed to create virtualenv at $WEBADMIN_VENV_PATH."
+    echo "Make sure python3-venv (or equivalent) is installed."
+    exit 1
+  fi
+
+  "$WEBADMIN_VENV_PATH/bin/python3" -m pip install --upgrade pip
+  "$WEBADMIN_VENV_PATH/bin/python3" -m pip install --ignore-installed -r "$APACHE_DOCUMENT_ROOT/fitcrackAPI/src/requirements.txt"
+
+  chmod -R 775 "$WEBADMIN_VENV_PATH"
+  chown -R $APACHE_USER:$APACHE_GROUP "$WEBADMIN_VENV_PATH"
+  echo "Back-end Python dependencies installed in virtualenv."
 fi
 
 sed -i "s|http://localhost:5000|$BACKEND_URI:$BACKEND_PORT|g" $BOINC_PROJECT_DIR/bin/measureUsage.py

--- a/webadmin/README.md
+++ b/webadmin/README.md
@@ -13,7 +13,6 @@ systemctl restart apache2
 On Centos/RHEL:
 ```
 yum install -y python3-devel python3 python3-pip python3-mod_wsgi
-pip3 install mysqlclient
 ```
 
 
@@ -22,7 +21,9 @@ pip3 install mysqlclient
 Install backend dependencies
 ```  
 cd /var/www/fitcrackAPI/src
-sudo pip3 install -r requirements.txt
+python3 -m venv /var/www/fitcrackAPI/.venv
+/var/www/fitcrackAPI/.venv/bin/python3 -m pip install --upgrade pip
+/var/www/fitcrackAPI/.venv/bin/python3 -m pip install -r requirements.txt
 ```
 
 
@@ -80,7 +81,7 @@ Change `/etc/apache2/sites-available/000-default.conf` to:
 Listen 5000
 <VirtualHost *:5000>
 
-	 WSGIDaemonProcess fitcrack user=boincadm group=boincadm threads=5
+	 WSGIDaemonProcess fitcrack user=boincadm group=boincadm threads=5 python-home=/var/www/fitcrackAPI/.venv
 	 WSGIScriptAlias / /var/www/fitcrackAPI/src/wsgi.py
 
 	<Directory /var/www/fitcrackAPI/src/>


### PR DESCRIPTION
## Summary
- stop installing WebAdmin backend Python packages into system Python as root
- update installer to create/use a dedicated venv at `fitcrackAPI/.venv` and install `requirements.txt` there
- configure Apache `mod_wsgi` to run with `python-home` pointing to that venv
- update installer and WebAdmin docs to reflect venv-based setup and remove `--break-system-packages` guidance
## Why
Recent pip behavior makes global root installs brittle and requires `--break-system-packages`, which is unsafe and non-ideal. A project-local virtual environment keeps Fitcrack dependencies isolated, reproducible, and distro-friendly.
## Test plan
- [x] `bash -n installer/install_webadmin.sh` passes after line-ending normalization on Linux shell
- [ ] run installer on a Linux host and verify `/var/www/fitcrackAPI/.venv` is created
- [ ] verify Apache backend vhost contains `WSGIDaemonProcess ... python-home=/var/www/fitcrackAPI/.venv`
- [ ] restart Apache and confirm WebAdmin backend endpoints load successfully
- [ ] confirm no global pip install step is required for WebAdmin backend dependencies
